### PR TITLE
fix: prevent StringIndexOutOfBoundsException in GetMsgQueue

### DIFF
--- a/src/main/java/com/newrelic/as400/GetMsgQueue.java
+++ b/src/main/java/com/newrelic/as400/GetMsgQueue.java
@@ -169,7 +169,9 @@ public class GetMsgQueue {
 				bFirstRun = true;
 			}
 		}
-		strJSONMetrics = strJSONMetrics.substring(0, strJSONMetrics.length() - 1);
+		if (!strJSONMetrics.isEmpty()) {
+			strJSONMetrics = strJSONMetrics.substring(0, strJSONMetrics.length() - 1);
+		}
 		System.out.println(strJSONHeader + strJSONMetrics + strJSONFooter);
 	}
 }


### PR DESCRIPTION
Fixes crash when message queue is empty or has no new messages.
- Added empty string check before substring operation


Resolves customer-reported exception:
java.lang.StringIndexOutOfBoundsException: Range [0, -1) out of bounds for length 0

