### PR TITLE
fix:  #9

### DIFF
--- a/src/main/resources/nri-as400-test.sh
+++ b/src/main/resources/nri-as400-test.sh
@@ -13,7 +13,7 @@ export INSTANCE=pub400.QSYSOPR
 
 execute_class () {
   start_time=`date +%s`
-  /usr/bin/java -cp ./nri-as400-1.2.0.jar -Xdiag -Dcom.ibm.as400.access.AS400.guiAvailable=false com.newrelic.as400.$1
+  /usr/bin/java -cp ./nri-as400.jar -Xdiag -Dcom.ibm.as400.access.AS400.guiAvailable=false com.newrelic.as400.$1
   echo Time to execute $2: $(expr `date +%s` - $start_time) seconds
 }
 


### PR DESCRIPTION
* Remove the version tag form `nri-as400-1.2.0.sh` in `execute_class` function from `nri-as400-test.sh` to avoid `ClassNotFoundException`.